### PR TITLE
添加Telegram推送支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ https://sleele.com/2020/11/24/docker-bilibili-helper/
 | SESSDATA   | 从 Cookie 中获取 |
 | BILI_JCT   | 从 Cookie 中获取 |SERVERPUSHKEY
 | SERVERPUSHKEY   | 通过server酱推送执行结果到微信(可选项) |
+| TELEGRAMBOTTOKEN | Telegram Bot的HTTP API (详见[BILIBILI-HELPER文档](https://github.com/JunzhouLiu/BILIBILI-HELPER#telegram%E8%AE%A2%E9%98%85%E6%89%A7%E8%A1%8C%E7%BB%93%E6%9E%9C)）|
+| TELEGRAMCHATID | Telegram上userinfobot返回的ID |
 
 ### 运行方式
 #### docker-compose  

--- a/root/app-conf/bh-run.sh
+++ b/root/app-conf/bh-run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 # 启动bilibili-helper
-cd /app && java -jar /app/BILIBILI-HELPER.jar ${DEDEUSERID} ${SESSDATA} ${BILI_JCT} ${SERVERPUSHKEY} | s6-setuidgid abc tee /config/bilibili-helper.log
+cd /app && java -jar /app/BILIBILI-HELPER.jar ${DEDEUSERID} ${SESSDATA} ${BILI_JCT} ${SERVERPUSHKEY} ${TELEGRAMBOTTOKEN} ${TELEGRAMCHATID} | s6-setuidgid abc tee /config/bilibili-helper.log

--- a/root/etc/services.d/bilbili-helper/run
+++ b/root/etc/services.d/bilbili-helper/run
@@ -13,7 +13,7 @@ then
     cron && tail -f /config/bilibili-helper.log
 fi
 
-cd /app && java -jar /app/BILIBILI-HELPER.jar ${DEDEUSERID} ${SESSDATA} ${BILI_JCT} ${SERVERPUSHKEY} | s6-setuidgid abc tee -a /config/bilibili-helper.log
+/app-conf/bh-run.sh
 
 echo -e "==================$(date +"%Y/%m/%d %H:%M:%S")==================" | s6-setuidgid abc tee -a /config/bilibili-helper.log
 echo -e "==========今天已签到完毕，下次签到时间为${TASK}后===========" | s6-setuidgid abc tee -a /config/bilibili-helper.log


### PR DESCRIPTION
 - 原项目已支持Telegram的推送，加入了对应的环境变量
 - `CRON`和`TASK`共用一个脚本`/app-conf/bh-run.sh`。和用`CRON`一样，使用`TASK`的话每次运行时日志也会被覆盖。